### PR TITLE
Support json

### DIFF
--- a/lib/ssdb-attr.rb
+++ b/lib/ssdb-attr.rb
@@ -6,6 +6,7 @@ require "active_support/concern"
 require "active_support/inflector"
 require "ssdb-attr/version"
 require "ssdb/attr"
+require "ssdb/type"
 
 module SSDBAttr
   class << self
@@ -121,7 +122,7 @@ module SSDBAttr
 
           value =
             if (raw_value = key_values[object.ssdb_attr_key(name)]).present?
-              object.typecaster(raw_value, object.class.ssdb_attr_definition[name])
+              object.decode_ssdb_attr(raw_value, object.class.ssdb_attr_definition[name])
             else
               object.public_send("#{name}_default_value")
             end

--- a/lib/ssdb-attr/version.rb
+++ b/lib/ssdb-attr/version.rb
@@ -1,3 +1,3 @@
 module SSDBAttr
-  VERSION = "0.1.4"
+  VERSION = "0.1.7"
 end

--- a/lib/ssdb/attr.rb
+++ b/lib/ssdb/attr.rb
@@ -5,7 +5,6 @@ module SSDB
     included do
       instance_variable_set(:@ssdb_attr_definition, {})
 
-      #before_validation :check_ssdb_json_changes
       after_create :save_ssdb_attrs
       after_update :save_ssdb_attrs
       after_commit :clear_ssdb_attrs, on: :destroy

--- a/lib/ssdb/type.rb
+++ b/lib/ssdb/type.rb
@@ -1,0 +1,1 @@
+require "ssdb/type/json"

--- a/lib/ssdb/type/json.rb
+++ b/lib/ssdb/type/json.rb
@@ -1,0 +1,36 @@
+module SSDB
+  module Type
+    class JSON
+      SUPPORT_TYPES = [
+        ::Array,
+        ::Hash
+      ]
+
+      def initialize(val)
+        @val = self.class.valid_type(val) ? val : nil
+      end
+
+      def encode
+        return if @val.nil?
+        ActiveSupport::JSON.encode(@val)
+      end
+
+      def self.decode(val)
+        return val if valid_type(val)
+        if val.is_a?(String) && val.present?
+          data = ActiveSupport::JSON.decode(val)
+          res = valid_type(data) && data || nil
+        end
+        if res.nil? && !val.nil?
+          ActiveSupport::Deprecation.warn("json ssdb-attr only supported to serialize array or hash data")
+        end
+        res
+      end
+
+      private
+      def self.valid_type(val)
+        SUPPORT_TYPES.any? { |type| val.is_a?(type) }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,9 @@ class Post < ActiveRecord::Base
   ssdb_attr :version, :integer, default: 1
   ssdb_attr :default_version, :integer, :default => 100
   ssdb_attr :field_with_validation, :string
+  ssdb_attr :json_array, :json, :default => []
+  ssdb_attr :json_hash, :json, :default => {}
+  ssdb_attr :json_ssdb, :json
 
   validate :validate_field
 

--- a/spec/ssdb/attr_spec.rb
+++ b/spec/ssdb/attr_spec.rb
@@ -8,7 +8,6 @@ describe SSDB::Attr do
     describe "@ssdb_attr_definition" do
       it "should set `@ssdb_attr_definition` correctly"  do
         ssdb_attr_definition = Post.instance_variable_get(:@ssdb_attr_definition)
-
         expect(ssdb_attr_definition["name"]).to eq("string")
         expect(ssdb_attr_definition["int_version"]).to eq("integer")
         expect(ssdb_attr_definition["default_title"]).to eq("string")
@@ -142,6 +141,29 @@ describe SSDB::Attr do
 
       it "default value with `:default` option" do
         expect(post.default_title).to eq("Untitled")
+      end
+    end
+
+    context "type: :json" do
+      it "default value" do
+        expect(post.json_ssdb).to be_nil
+        expect(post.json_array).to eq([])
+        expect(post.json_hash).to eq({})
+      end
+
+      it "decode to correct data" do
+        post.json_ssdb = [1, 2]
+        expect(post.json_ssdb).to eq([1, 2])
+        post.json_ssdb = nil
+        expect(post.json_ssdb).to be_nil
+        post.json_ssdb = { :a => 1 }
+        expect(post.json_ssdb).to eq( { :a => 1 } )
+
+        post.json_ssdb = 123
+        expect(post.json_ssdb).to be_nil
+        post.json_ssdb = { :a => 1 }
+        post.json_ssdb = "123"
+        expect(post.json_ssdb).to be_nil
       end
     end
 

--- a/spec/ssdb/type/json_spec.rb
+++ b/spec/ssdb/type/json_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+describe SSDB::Type::JSON do
+  describe ".inititalize" do
+    context "valid data type" do
+      it "hash" do 
+        xx = SSDB::Type::JSON.new({:a => 1})
+        expect(xx.instance_variable_get(:@val)).to eq(:a => 1)
+      end
+
+      it "array" do
+        xx = SSDB::Type::JSON.new(1.upto(10).to_a)
+        expect(xx.instance_variable_get(:@val)).to eq(1.upto(10).to_a)
+      end
+    end
+
+    context "invalid data type" do
+      it do 
+        xx = SSDB::Type::JSON.new(11)
+        expect(xx.instance_variable_get(:@val)).to be_nil
+
+        xx = SSDB::Type::JSON.new("abc")
+        expect(xx.instance_variable_get(:@val)).to be_nil
+      end
+    end
+  end
+
+  describe ".encode" do
+    it do
+      xx = SSDB::Type::JSON.new(11)
+      expect(xx.encode).to be_nil
+      xx = SSDB::Type::JSON.new("abc")
+      expect(xx.encode).to be_nil
+
+      xx = SSDB::Type::JSON.new([1])
+      expect(xx.encode).to eq([1].to_json)
+
+      xx = SSDB::Type::JSON.new(:a => 1)
+      expect(xx.encode).to eq({:a => 1}.to_json)
+    end
+  end
+
+  describe "#decode" do
+    context "decode blank string" do
+      it do
+        expect(SSDB::Type::JSON.decode("")).to be_nil
+      end
+    end
+
+    context "decode invalid data type json" do
+      it do
+        str = ActiveSupport::JSON.encode(1)
+        expect(SSDB::Type::JSON.decode(str)).to be_nil
+
+        str = ActiveSupport::JSON.encode("abc")
+        expect(SSDB::Type::JSON.decode(str)).to be_nil
+      end
+    end
+
+    context "decode valid data type" do
+      it "hash" do
+        expect(SSDB::Type::JSON.decode(:a => 1)).to eq(:a => 1)
+      end
+
+      it "array" do
+        expect(SSDB::Type::JSON.decode([1, 2])).to eq([1, 2])
+      end
+    end
+
+    context "decode valid data type json" do
+      it do
+        str = [1, 2].to_json
+        expect(SSDB::Type::JSON.decode(str)).to eq([1, 2])
+
+        str = {:a => 2}.to_json
+        expect(SSDB::Type::JSON.decode(str)).to eq("a" => 2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
支持 json 格式存储的 hash 和 array
 
由于 hash 和 array 的操作经常不是调用 attr= 的方式赋值，所以 attr_will_change! 没有正常调用就会导致 changes 不正常。
解决方案是：每次取 ssdb_attr 都记录到 ssdb_attr_old_values, 方便计算出 changed_ssdb_attrs 和 ssdb_changes，并在 save_ssdb_attrs 时刷新 ssdb_attr_old_values。